### PR TITLE
feat(frontend): add dark mode support with theme toggle and system pr…

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import { ThemeProvider } from "../components/ui/ThemeProvider";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -51,7 +52,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ThemeProvider>
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -13,6 +13,7 @@ import { ProductGrid } from "@/components/products/ProductGrid";
 import { EmptyState } from "@/components/products/EmptyState";
 import { Pagination } from "@/components/products/Pagination";
 import Link from "next/link";
+import { ThemeToggleButton } from "@/components/ui/ThemeToggleButton";
 
 function ProductDashboardContent() {
   const searchParams = useSearchParams();
@@ -191,6 +192,8 @@ function ProductDashboardContent() {
                 <span>GitHub</span>
                 <Star size={12} fill="currentColor" className="text-yellow-400" />
               </a>
+
+              <ThemeToggleButton />
 
             </div>
 

--- a/frontend/components/ui/ThemeProvider.tsx
+++ b/frontend/components/ui/ThemeProvider.tsx
@@ -1,0 +1,69 @@
+"use client";
+import React, { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+// Types for theme
+export type Theme = "light" | "dark";
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("theme");
+      if (stored === "light" || stored === "dark") return stored;
+      // Default to system preference
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      return prefersDark ? "dark" : "light";
+    }
+    return "light";
+  });
+
+  useEffect(() => {
+    localStorage.setItem("theme", theme);
+    const root = window.document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+      root.classList.remove("light");
+    } else {
+      root.classList.remove("dark");
+      root.classList.add("light");
+    }
+  }, [theme]);
+
+  // Listen to system preference changes
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => {
+      if (!localStorage.getItem("theme")) {
+        setTheme(media.matches ? "dark" : "light");
+      }
+    };
+    media.addEventListener("change", handler);
+    return () => media.removeEventListener("change", handler);
+  }, []);
+
+  const toggleTheme = () => setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}; 

--- a/frontend/components/ui/ThemeToggleButton.tsx
+++ b/frontend/components/ui/ThemeToggleButton.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { useTheme } from "./ThemeProvider";
+import { Sun, Moon } from "lucide-react";
+
+export function ThemeToggleButton() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+      className="flex items-center justify-center w-9 h-9 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+      type="button"
+    >
+      {theme === "dark" ? (
+        <Sun className="w-5 h-5 text-yellow-400" />
+      ) : (
+        <Moon className="w-5 h-5 text-slate-700" />
+      )}
+    </button>
+  );
+} 


### PR DESCRIPTION
##  Description

This PR adds dark mode support to the frontend, fulfilling [Issue #1](https://github.com/meta-boy/mech-alligator/issues/1).

### Features
- Implements a `ThemeProvider` that manages light/dark theme, defaults to system preference, and persists the choice in localStorage.
- Adds a theme toggle button to the homepage header for switching between light and dark modes.
- Ensures all shadcn-ui and Tailwind components respond to dark mode using CSS variables and Tailwind's `dark:` classes.
- Applies the theme class to the `<html>` element for global styling.


Closes #1.